### PR TITLE
Fix DS-types COUNTER, DERIVE, ABSOLUTE only accept INT values

### DIFF
--- a/webfrontend/cgi/import.cgi
+++ b/webfrontend/cgi/import.cgi
@@ -540,7 +540,9 @@ sub generate_import_table
 		my $statdef_nr = 0;
 		foreach my $statdef (sort keys %dbsettings) {
 			$statdef_nr++;
-			if ($statdef_nr == 1) {
+		# Preselect Nr. 2 (Energy-Definition) if Loxone-Stat is "Energy", else Nr. 1
+		if ((($statdef_nr == 1) && ($lox_statsobject{$statsobj}{Type} ne "Energy")) || 
+				(($statdef_nr == 2) && ($lox_statsobject{$statsobj}{Type} eq "Energy"))) {
 				$statdef_dropdown .= "<option selected value=\"$statdef_nr\">$dbsettings{$statdef}{Name}</option>\n";
 			} else {
 				$statdef_dropdown .= "<option value=\"$statdef_nr\">$dbsettings{$statdef}{Name}</option>\n";


### PR DESCRIPTION
import.pl:
- Fixed on these types, round values (using ceil)
- Reduced import bulk from 2000 to 1000
fetch.pl:
- Added use RRDs and POSIX ceil
- Use RRDs::info to get DS type
- Round value when necessary with ceil
import.cgi:
- Improved: Preselect Stats Template 2 (Verbrauchszähler) if LoxPlan-block is "Energy"
index.cgi
- Added delete stats function for easier testing/debugging